### PR TITLE
[refactor] 모달 렌더링 구조, 모달 포커스, 게임 분기 처리 개선 및 버튼 포커스 개선

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -26,7 +26,15 @@ body {
 }
 
 .toggle-radio input[type='radio'] {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  overflow: hidden;
+  border: 0;
+}
+
+.toggle-radio input[type='radio']:focus-visible + label {
+  outline: 2px solid var(--primary-black);
+  outline-offset: 2px;
 }
 
 .toggle-radio .btn {
@@ -112,4 +120,5 @@ body {
   line-height: noraml;
   color: #0f1e69;
   user-select: none;
+  outline-offset: 4px;
 }

--- a/src/components/modal/description.js
+++ b/src/components/modal/description.js
@@ -8,7 +8,9 @@
  */
 export function handleDescriptionModal(dialog) {
   // 1. 게임 타입 확인 (acidrain, defense, whack, quiz)
-  const gameType = document.body.dataset.game;
+  const container = dialog.closest('[data-game]');
+  const gameType = container?.dataset.game;
+
   if (!gameType) {
     console.warn('게임 타입이 지정되지 않았습니다.');
     return;

--- a/src/components/modal/description.js
+++ b/src/components/modal/description.js
@@ -1,6 +1,6 @@
 /**
  * 게임 설명 모달을 열 때 내용을 채워 넣는다.
- * 1) <body data-game=""> 값으로 게임 타입 확인
+ * 1) <body>의 하위 컨테이너의 'data-game' 속성 값으로 게임 타입 확인
  * 2) /data/game-info.json에서 설명 문자열 fetch
  * 3) **강조**·줄바꿈을 HTML 요소로 변환해 .modal-content에 삽입
  *

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -4,11 +4,11 @@
   padding: 0;
   margin: 0;
 
-  position: fixed;
+  position: absolute;
   inset: 0;
 
   width: 100%;
-  height: 100vh;
+  height: 100%;
 
   background-color: rgba(0, 0, 0, 0.5);
 

--- a/src/components/modal/modal.css
+++ b/src/components/modal/modal.css
@@ -1,3 +1,19 @@
+body.modal-opened {
+  overflow: hidden; /* 모달 열릴 때 body 스크롤 방지 */
+  pointer-events: none; /* 모달 외부 클릭/상호작용 방지 */
+  user-select: none; /* 모달 외부 텍스트 선택 방지 */
+}
+
+body.modal-opened .monitor-frame {
+  user-select: none; /* 모니터 프레임 안쪽 텍스트 선택 방지 */
+}
+
+body.modal-opened dialog.modal,
+body.modal-opened dialog.modal * {
+  pointer-events: auto; /* 모달 내부 클릭/상호작용 허용 */
+  user-select: auto; /* 모달 내부 텍스트 선택 허용 */
+}
+
 /* 공통 모달 스타일 */
 .modal {
   border: none;

--- a/src/components/modal/modal.html
+++ b/src/components/modal/modal.html
@@ -17,116 +17,118 @@
     <script type="module" src="/src/components/slider/slider.js"></script>
     <script type="module" src="/src/components/slider/slider.css"></script>
   </head>
-  <body data-game="quiz">
-    <h1>모달 컴포넌트</h1>
-    <!-- 게임 설명에 쓰이는 모달 -->
-    <div class="modal-container">
-      <button class="modal-open" data-type="description">게임 설명 모달 열기(테스트용)</button>
-      <dialog class="modal" data-type="description">
-        <div class="modal-inner">
-          <h2 class="modal-title">게임 설명</h2>
-          <button class="modal-close-button" type="button"><img src="/assets/icons/close.svg" alt="닫기" /></button>
-          <div class="modal-content">
-            <!-- 모달 콘텐츠 삽입 -->
-          </div>
-        </div>
-      </dialog>
-    </div>
-    <!-- 점수판에 쓰이는 모달 -->
-    <div class="modal-container">
-      <button class="modal-open" data-type="scoreboard">점수판 모달 열기(테스트용)</button>
-      <dialog class="modal" data-type="scoreboard">
-        <div class="modal-inner">
-          <h2 class="modal-title">점수판</h2>
-          <button class="modal-close-button" type="button"><img src="/assets/icons/close.svg" alt="닫기" /></button>
-          <div class="modal-content">
-            <!-- 모달 콘텐츠 삽입 -->
-          </div>
-        </div>
-      </dialog>
-    </div>
-    <!-- 설정에 쓰이는 모달 -->
-    <div class="modal-container">
-      <button class="modal-open" data-type="settings">설정 모달 열기 (테스트용)</button>
-      <dialog class="modal" data-type="settings">
-        <div class="modal-inner">
-          <h2 class="modal-title">설정</h2>
-          <button class="modal-close-button" type="button"><img src="/assets/icons/close.svg" alt="닫기" /></button>
-          <div class="modal-content">
-            <!-- 모달 콘텐츠 삽입 -->
-            <div class="wrapper mode">
-              <span class="text">모드 선택</span>
-              <div class="divider"></div>
-              <div class="toggle-radio">
-                <input type="radio" id="normal" name="mode" checked />
-                <label for="normal" class="btn normal">일반 모드</label>
-                <input type="radio" id="dev" name="mode" />
-                <label for="dev" class="btn dev">개발자 모드</label>
-              </div>
+  <body>
+    <div class="modals-container" data-game="quiz">
+      <h1>모달 컴포넌트</h1>
+      <!-- 게임 설명에 쓰이는 모달 -->
+      <div class="modal-container">
+        <button class="modal-open" data-type="description">게임 설명 모달 열기(테스트용)</button>
+        <dialog class="modal" data-type="description">
+          <div class="modal-inner">
+            <h2 class="modal-title">게임 설명</h2>
+            <button class="modal-close-button" type="button"><img src="/assets/icons/close.svg" alt="닫기" /></button>
+            <div class="modal-content">
+              <!-- 모달 콘텐츠 삽입 -->
             </div>
-            <div class="wrapper">
-              <span class="text">BGM</span>
-              <div class="divider"></div>
-              <div class="bgm-slider-custom">
-                <div class="progress-bg">
-                  <div class="progress-fill"></div>
+          </div>
+        </dialog>
+      </div>
+      <!-- 점수판에 쓰이는 모달 -->
+      <div class="modal-container">
+        <button class="modal-open" data-type="scoreboard">점수판 모달 열기(테스트용)</button>
+        <dialog class="modal" data-type="scoreboard">
+          <div class="modal-inner">
+            <h2 class="modal-title">점수판</h2>
+            <button class="modal-close-button" type="button"><img src="/assets/icons/close.svg" alt="닫기" /></button>
+            <div class="modal-content">
+              <!-- 모달 콘텐츠 삽입 -->
+            </div>
+          </div>
+        </dialog>
+      </div>
+      <!-- 설정에 쓰이는 모달 -->
+      <div class="modal-container">
+        <button class="modal-open" data-type="settings">설정 모달 열기 (테스트용)</button>
+        <dialog class="modal" data-type="settings">
+          <div class="modal-inner">
+            <h2 class="modal-title">설정</h2>
+            <button class="modal-close-button" type="button"><img src="/assets/icons/close.svg" alt="닫기" /></button>
+            <div class="modal-content">
+              <!-- 모달 콘텐츠 삽입 -->
+              <div class="wrapper mode">
+                <span class="text">모드 선택</span>
+                <div class="divider"></div>
+                <div class="toggle-radio">
+                  <input type="radio" id="normal" name="mode" checked />
+                  <label for="normal" class="btn normal">일반 모드</label>
+                  <input type="radio" id="dev" name="mode" />
+                  <label for="dev" class="btn dev">개발자 모드</label>
                 </div>
-                <input type="range" min="0" max="100" step="20" value="60" aria-label="음량 조절" id="bgm-range" />
               </div>
-              <audio hidden id="test-audio" src="/assets/audio/bgm/main-XRayVision-Slynk.mp3" controls></audio>
-            </div>
-            <div class="wrapper">
-              <span class="text">효과음</span>
-              <div class="divider"></div>
-              <div class="bgm-slider-custom">
-                <div class="progress-bg">
-                  <div class="progress-fill"></div>
+              <div class="wrapper">
+                <span class="text">BGM</span>
+                <div class="divider"></div>
+                <div class="bgm-slider-custom">
+                  <div class="progress-bg">
+                    <div class="progress-fill"></div>
+                  </div>
+                  <input type="range" min="0" max="100" step="20" value="60" aria-label="음량 조절" id="bgm-range" />
                 </div>
-                <input type="range" min="0" max="100" step="20" value="60" aria-label="음량 조절" id="effect-range" />
+                <audio hidden id="test-audio" src="/assets/audio/bgm/main-XRayVision-Slynk.mp3" controls></audio>
               </div>
-              <audio hidden id="effect-audio" src="/assets/audio/bgm/main-XRayVision-Slynk.mp3" controls></audio>
+              <div class="wrapper">
+                <span class="text">효과음</span>
+                <div class="divider"></div>
+                <div class="bgm-slider-custom">
+                  <div class="progress-bg">
+                    <div class="progress-fill"></div>
+                  </div>
+                  <input type="range" min="0" max="100" step="20" value="60" aria-label="음량 조절" id="effect-range" />
+                </div>
+                <audio hidden id="effect-audio" src="/assets/audio/bgm/main-XRayVision-Slynk.mp3" controls></audio>
+              </div>
+              <button type="button" class="exit-button" aria-label="게임을 종료하고 메인 화면으로 이동">게임 종료</button>
             </div>
-            <button type="button" class="exit-button" aria-label="게임을 종료하고 메인 화면으로 이동">게임 종료</button>
           </div>
-        </div>
-      </dialog>
-    </div>
-    <!-- 게임 일시정지 모달 -->
-    <div class="modal-container">
-      <button class="modal-open" data-type="pause">게임 일시정지 테스트용 버튼</button>
-      <dialog class="modal" data-type="pause">
-        <div class="modal-inner">
-          <h2 class="modal-title">게임을 그만하시겠습니까?</h2>
-          <div class="modal-content">
-            <button type="button" class="pause-modal continue-btn">계속 하기</button>
-            <button type="button" class="pause-modal retry-btn">다시 하기</button>
-            <button type="button" class="pause-modal main-btn">메인 화면</button>
+        </dialog>
+      </div>
+      <!-- 게임 일시정지 모달 -->
+      <div class="modal-container">
+        <button class="modal-open" data-type="pause">게임 일시정지 테스트용 버튼</button>
+        <dialog class="modal" data-type="pause">
+          <div class="modal-inner">
+            <h2 class="modal-title">게임을 그만하시겠습니까?</h2>
+            <div class="modal-content">
+              <button type="button" class="pause-modal continue-btn">계속 하기</button>
+              <button type="button" class="pause-modal retry-btn">다시 하기</button>
+              <button type="button" class="pause-modal main-btn">메인 화면</button>
+            </div>
           </div>
-        </div>
-      </dialog>
-    </div>
-    <!-- 닉네임 입력 모달 -->
-    <div class="modal-container">
-      <button class="modal-open" data-type="register">닉네임 입력 모달 테스트 버튼</button>
-      <dialog class="modal" data-type="register">
-        <div class="modal-inner">
-          <h2 class="modal-title">닉네임을 입력해 주세요!</h2>
-          <div class="modal-content">
-            <!-- 모달 콘텐츠 삽입 -->
-            <form id="nickname-register-form">
-              <label for="nickname-input" class="sr-only">닉네임</label>
-              <!-- 닉네임 입력 필드 -->
-              <input type="text" id="nickname-input" name="nickname" maxlength="10" placeholder="최대 10자" required autocomplete="off" />
-              <!-- 닉네임 중복 여부 확인 메시지 -->
-              <p class="nickname-check-message">이미 사용 중인 닉네임입니다.</p>
-              <div class="modal-button-container">
-                <button type="submit" class="register-submit-button">확인</button>
-                <button type="button" class="modal-close-button">취소</button>
-              </div>
-            </form>
+        </dialog>
+      </div>
+      <!-- 닉네임 입력 모달 -->
+      <div class="modal-container">
+        <button class="modal-open" data-type="register">닉네임 입력 모달 테스트 버튼</button>
+        <dialog class="modal" data-type="register">
+          <div class="modal-inner">
+            <h2 class="modal-title">닉네임을 입력해 주세요!</h2>
+            <div class="modal-content">
+              <!-- 모달 콘텐츠 삽입 -->
+              <form id="nickname-register-form">
+                <label for="nickname-input" class="sr-only">닉네임</label>
+                <!-- 닉네임 입력 필드 -->
+                <input type="text" id="nickname-input" name="nickname" maxlength="10" placeholder="최대 10자" required autocomplete="off" />
+                <!-- 닉네임 중복 여부 확인 메시지 -->
+                <p class="nickname-check-message">이미 사용 중인 닉네임입니다.</p>
+                <div class="modal-button-container">
+                  <button type="submit" class="register-submit-button">확인</button>
+                  <button type="button" class="modal-close-button">취소</button>
+                </div>
+              </form>
+            </div>
           </div>
-        </div>
-      </dialog>
+        </dialog>
+      </div>
     </div>
   </body>
 </html>

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -19,7 +19,7 @@ modalOpenButtons.forEach((button) => {
 
   // 열기 이벤트
   button.addEventListener('click', () => {
-    dialog.showModal();
+    dialog.show();
 
     // 타입에 따른 JS 분기 처리
     switch (type) {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -4,49 +4,155 @@ import { handleSettingsModal } from './settings.js';
 import { handlePauseModal } from './pause-modal.js';
 import { handleRegisterModal } from './register-modal.js';
 
-const modalOpenButtons = document.querySelectorAll('.modal-open');
+{
+  const modalOpenButtons = document.querySelectorAll('.modal-open');
 
-// 모든 모달 열기 버튼 처리
-modalOpenButtons.forEach((button) => {
-  // data-type이 있는 경우
-  const type = button.dataset.type;
+  // 모든 모달 열기 버튼 처리
+  modalOpenButtons.forEach((button) => {
+    // data-type이 있는 경우
+    const type = button.dataset.type;
 
-  if (!type) return;
+    if (!type) return;
 
-  // 해당 타입의 모달 찾기
-  const dialog = document.querySelector(`dialog.modal[data-type="${type}"]`);
-  if (!dialog) return;
+    // 해당 타입의 모달 찾기
+    const dialog = document.querySelector(`dialog.modal[data-type="${type}"]`);
+    if (!dialog) return;
 
-  // 열기 이벤트
-  button.addEventListener('click', () => {
-    dialog.show();
+    // 열기 이벤트
+    button.addEventListener('click', () => {
+      // 다이얼로그를 열기 전의 포커스된 요소를 저장 (닫힐 때 복원용)
+      const previouslyFocusedElement = document.activeElement;
 
-    // 타입에 따른 JS 분기 처리
-    switch (type) {
-      case 'description':
-        handleDescriptionModal(dialog);
-        break;
-      case 'scoreboard':
-        handleScoreboardModal(dialog);
-        break;
-      case 'settings':
-        handleSettingsModal(dialog);
-        break;
-      case 'pause':
-        handlePauseModal(dialog);
-        break;
-      case 'register':
-        handleRegisterModal(dialog);
-        break;
+      dialog.show();
+      trapFocus(dialog); // 포커스 트랩 추가
+
+      // 타입에 따른 JS 분기 처리
+      switch (type) {
+        case 'description':
+          handleDescriptionModal(dialog);
+          break;
+        case 'scoreboard':
+          handleScoreboardModal(dialog);
+          break;
+        case 'settings':
+          handleSettingsModal(dialog);
+          break;
+        case 'pause':
+          handlePauseModal(dialog);
+          break;
+        case 'register':
+          handleRegisterModal(dialog);
+          break;
+      }
+      // 다이얼로그가 닫힐 때 포커스 복원
+      // 'close' 이벤트는 dialog.close()에 의해 발생하거나, Escape 키를 누를 때 발생
+      // dialog.show()로 열었을 때는 Escape 키로 닫히지 않으므로, trapFocus에서 Escape를 처리해야 한다.
+      dialog.addEventListener(
+        'close',
+        () => {
+          if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
+            previouslyFocusedElement.focus();
+          }
+        },
+        { once: true }
+      ); // 한 번만 실행되도록
+    });
+
+    // 닫기 버튼 처리 (한 번만 바인딩)
+    if (!dialog.dataset.closeBound) {
+      dialog.addEventListener('click', (e) => {
+        const closeBtn = e.target.closest('.modal-close-button');
+        if (closeBtn) dialog.close();
+      });
+      dialog.dataset.closeBound = 'true';
     }
   });
+}
 
-  // 닫기 버튼 처리 (한 번만 바인딩)
-  if (!dialog.dataset.closeBound) {
-    dialog.addEventListener('click', (e) => {
-      const closeBtn = e.target.closest('.modal-close-button');
-      if (closeBtn) dialog.close();
-    });
-    dialog.dataset.closeBound = 'true';
-  }
-});
+/**
+ * 포커스 가능한 요소를 반환한다.
+ *
+ * @param {HTMLElement} element - 포커스를 찾을 기준 요소
+ * @returns {HTMLElement[]} - 포커스 가능한 요소 배열
+ */
+function getFocusableElements(element) {
+  const selector = ['button:not([disabled])', '[href]', 'input:not([disabled])', 'select:not([disabled])', 'textarea:not([disabled])', '[tabindex]:not([tabindex="-1"]):not([disabled])'].join(',');
+
+  const elements = element.querySelectorAll(selector);
+
+  // 화면에 실제 보이는 요소만 필터링
+  const visibleElements = Array.from(elements).filter((el) => {
+    return el.offsetWidth > 0 || el.offsetHeight > 0;
+  });
+
+  return visibleElements;
+}
+
+/**
+ * keydown 핸들러를 생성한다.
+ *
+ * @param {HTMLElement} firstEl 첫 포커스 요소
+ * @param {HTMLElement} lastEl 마지막 포커스 요소
+ * @param {HTMLDialogElement} dialog 대상 모달
+ * @returns {Function} keydown 이벤트 핸들러
+ */
+function createKeydownHandler(firstEl, lastEl, dialog) {
+  return function handleKeydown(e) {
+    if (e.key === 'Tab') {
+      const isForward = !e.shiftKey;
+
+      if (isForward && document.activeElement === lastEl) {
+        e.preventDefault();
+        firstEl.focus();
+      } else if (!isForward && document.activeElement === firstEl) {
+        e.preventDefault();
+        lastEl.focus();
+      }
+    }
+  };
+}
+
+/**
+ * 다이얼로그 닫힘 핸들러를 생성한다.
+ *
+ * @param {HTMLDialogElement} dialog 대상 모달
+ * @param {Function} keydownHandler keydown 이벤트 핸들러
+ * @param {HTMLElement} [prevFocusedEl] 이전 포커스 복원용 요소
+ * @returns {Function} close 이벤트 핸들러
+ */
+function createCloseHandler(dialog, keydownHandler, prevFocusedEl) {
+  return function handleClose() {
+    dialog.removeEventListener('keydown', keydownHandler);
+    dialog.removeEventListener('close', handleClose);
+
+    if (prevFocusedEl && typeof prevFocusedEl.focus === 'function') {
+      prevFocusedEl.focus();
+    }
+  };
+}
+
+/**
+ * 포커스를 trap하고, Escape 키로 닫기 및 포커스 복원까지 처리
+ *
+ * @param {HTMLDialogElement} dialog 대상 모달
+ */
+function trapFocus(dialog) {
+  const focusableElements = getFocusableElements(dialog);
+  if (focusableElements.length === 0) return;
+
+  const firstEl = focusableElements[0];
+  const lastEl = focusableElements[focusableElements.length - 1];
+
+  const prevFocusedEl = document.activeElement;
+
+  // 렌더 후 포커스 이동
+  requestAnimationFrame(() => {
+    firstEl.focus();
+  });
+
+  const keydownHandler = createKeydownHandler(firstEl, lastEl, dialog);
+  const closeHandler = createCloseHandler(dialog, keydownHandler, prevFocusedEl);
+
+  dialog.addEventListener('keydown', keydownHandler);
+  dialog.addEventListener('close', closeHandler);
+}

--- a/src/components/modal/pause-modal.js
+++ b/src/components/modal/pause-modal.js
@@ -4,17 +4,17 @@ import { handleAcidRainPause } from './pause-modal/acidrain-pause.js';
 import { handleWhackPause } from './pause-modal/whack-pause.js';
 
 /**
- * 현재 게임의 타입(`data-game` 속성)을 기준으로 적절한 일시정지 모달 핸들러를 호출합니다.
+ * 현재 게임의 타입('data-game' 속성)을 기준으로 적절한 일시정지 모달 핸들러를 호출한다.
  *
- * 이 함수는 `<body>` 요소의 `data-game` 속성을 읽어, 각 게임별 pause 핸들러
- * (`handleWhackPause`, `handleQuizPause`, `handleDefensePause`, `handleAcidRainPause`)를 호출합니다.
+ * 이 함수는 <body>의 하위 컨테이너에서 'data-game' 속성을 읽어, 각 게임별 pause 핸들러
+ * ('handleWhackPause', 'handleQuizPause', 'handleDefensePause','handleAcidRainPause')를 호출한다.
  *
- * - 게임 타입이 지정되지 않은 경우, 경고 로그를 출력하고 종료됩니다.
- * - 지원하지 않는 게임 타입의 경우, 에러를 발생시킵니다.
+ * - 게임 타입이 지정되지 않은 경우, 경고 로그를 출력하고 종료된다.
+ * - 지원하지 않는 게임 타입의 경우, 에러를 발생시킨다.
  *
- * @param {HTMLDialogElement} dialog - 일시정지 모달 `<dialog>` 요소
+ * @param {HTMLDialogElement} dialog - 일시정지 모달 '<dialog>' 요소
  *
- * @throws {Error} 알 수 없는 게임 타입이 지정된 경우 예외를 발생시킵니다.
+ * @throws {Error} 알 수 없는 게임 타입이 지정된 경우 예외를 발생시킨다.
  */
 export function handlePauseModal(dialog) {
   // 1. 게임 타입 확인 (acidrain, defense, whack, quiz)

--- a/src/components/modal/pause-modal.js
+++ b/src/components/modal/pause-modal.js
@@ -6,7 +6,7 @@ import { handleWhackPause } from './pause-modal/whack-pause.js';
 /**
  * 현재 게임의 타입('data-game' 속성)을 기준으로 적절한 일시정지 모달 핸들러를 호출한다.
  *
- * 이 함수는 <body>의 하위 컨테이너에서 'data-game' 속성을 읽어, 각 게임별 pause 핸들러
+ * 이 함수는 <body>의 하위 컨테이너의 'data-game' 속성을 읽어, 각 게임별 pause 핸들러
  * ('handleWhackPause', 'handleQuizPause', 'handleDefensePause','handleAcidRainPause')를 호출한다.
  *
  * - 게임 타입이 지정되지 않은 경우, 경고 로그를 출력하고 종료된다.

--- a/src/components/modal/pause-modal.js
+++ b/src/components/modal/pause-modal.js
@@ -18,7 +18,9 @@ import { handleWhackPause } from './pause-modal/whack-pause.js';
  */
 export function handlePauseModal(dialog) {
   // 1. 게임 타입 확인 (acidrain, defense, whack, quiz)
-  const gameType = document.body.dataset.game;
+  const container = dialog.closest('[data-game]');
+  const gameType = container?.dataset.game;
+
   if (!gameType) {
     console.warn('게임 타입이 지정되지 않았습니다.');
     return;

--- a/src/components/modal/pause-modal/acidrain-pause.js
+++ b/src/components/modal/pause-modal/acidrain-pause.js
@@ -1,17 +1,17 @@
 import { setupPauseDialogClickHandler } from './pause-util.js';
 
 /**
- * 산성비(Acid Rain) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정합니다.
+ * 산성비(Acid Rain) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정한다.
  *
- * 이 함수는 pause 모달(`<dialog>` 요소)에 대해 산성비 게임 전용 pause 로직을 바인딩하며,
- * 버튼 클릭 시 수행할 동작을 `setupPauseDialogClickHandler`를 통해 등록합니다.
+ * 이 함수는 pause 모달('<dialog>' 요소)에 대해 산성비 게임 전용 pause 로직을 바인딩하며,
+ * 버튼 클릭 시 수행할 동작을 'setupPauseDialogClickHandler'를 통해 등록한다.
  *
- * 각 버튼의 동작은 다음과 같습니다:
- * - `.continue-btn`: 게임을 계속 진행
- * - `.retry-btn`: 게임을 처음부터 다시 시작
- * - `.main-btn`: 메인 화면으로 이동
+ * 각 버튼의 동작은 다음과 같다.
+ * - '.continue-btn': 게임을 계속 진행
+ * - '.retry-btn': 게임을 처음부터 다시 시작
+ * - '.main-btn': 메인 화면으로 이동
  *
- * @param {HTMLDialogElement} dialog - 일시정지 모달 `<dialog>` 요소
+ * @param {HTMLDialogElement} dialog - 일시정지 모달 '<dialog>' 요소
  */
 export function handleAcidRainPause(dialog) {
   // console.log는 디버깅용으로 사용

--- a/src/components/modal/pause-modal/defense-pause.js
+++ b/src/components/modal/pause-modal/defense-pause.js
@@ -1,17 +1,17 @@
 import { setupPauseDialogClickHandler } from './pause-util.js';
 
 /**
- * 디펜스(Defense) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정합니다.
+ * 디펜스(Defense) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정한다.
  *
- * 이 함수는 pause 모달(`<dialog>` 요소)에 대해 디펜스 게임 전용 pause 로직을 바인딩하며,
- * 버튼 클릭 시 수행할 동작을 `setupPauseDialogClickHandler`를 통해 등록합니다.
+ * 이 함수는 pause 모달('<dialog>' 요소)에 대해 디펜스 게임 전용 pause 로직을 바인딩하며,
+ * 버튼 클릭 시 수행할 동작을 'setupPauseDialogClickHandler'를 통해 등록한다.
  *
- * 각 버튼의 동작은 다음과 같습니다:
- * - `.continue-btn`: 게임을 계속 진행
- * - `.retry-btn`: 게임을 처음부터 다시 시작
- * - `.main-btn`: 메인 화면으로 이동
+ * 각 버튼의 동작은 다음과 같다.
+ * - '.continue-btn': 게임을 계속 진행
+ * - '.retry-btn': 게임을 처음부터 다시 시작
+ * - '.main-btn': 메인 화면으로 이동
  *
- * @param {HTMLDialogElement} dialog - 일시정지 모달 `<dialog>` 요소
+ * @param {HTMLDialogElement} dialog - 일시정지 모달 '<dialog>' 요소
  */
 export function handleDefensePause(dialog) {
   // console.log는 디버깅용으로 사용

--- a/src/components/modal/pause-modal/pause-util.js
+++ b/src/components/modal/pause-modal/pause-util.js
@@ -1,18 +1,18 @@
 /**
- * 일시정지 모달(dialog)에 클릭 이벤트 핸들러를 등록합니다.
+ * 일시정지 모달(dialog)에 클릭 이벤트 핸들러를 등록한다.
  *
- * 세 가지 버튼에 대한 처리를 담당합니다:
- * - `.continue-btn`: 게임 계속하기
- * - `.retry-btn`: 게임 다시 시작
- * - `.main-btn`: 메인 화면으로 이동
+ * 세 가지 버튼에 대한 처리를 담당한다.
+ * - '.continue-btn': 게임 계속하기
+ * - '.retry-btn': 게임 다시 시작
+ * - '.main-btn': 메인 화면으로 이동
  *
- * 이미 이벤트 리스너가 등록된 경우, 중복 등록을 방지합니다.
+ * 이미 이벤트 리스너가 등록된 경우, 중복 등록을 방지한다.
  *
- * @param {HTMLDialogElement} dialog - 클릭 이벤트를 처리할 `<dialog>` 요소
+ * @param {HTMLDialogElement} dialog - 클릭 이벤트를 처리할 '<dialog>' 요소
  * @param {Object} handlers - 각 버튼에 대응하는 콜백 핸들러 객체
- * @param {Function} [handlers.continue] - `.continue-btn` 클릭 시 호출될 함수
- * @param {Function} [handlers.retry] - `.retry-btn` 클릭 시 호출될 함수
- * @param {Function} [handlers.main] - `.main-btn` 클릭 시 호출될 함수
+ * @param {Function} [handlers.continue] - '.continue-btn' 클릭 시 호출될 함수
+ * @param {Function} [handlers.retry] - '.retry-btn' 클릭 시 호출될 함수
+ * @param {Function} [handlers.main] - '.main-btn' 클릭 시 호출될 함수
  */
 export function setupPauseDialogClickHandler(dialog, handlers) {
   // 이미 이벤트 리스너가 등록된 상태라면 중복 방지

--- a/src/components/modal/pause-modal/quiz-pause.js
+++ b/src/components/modal/pause-modal/quiz-pause.js
@@ -1,17 +1,17 @@
 import { setupPauseDialogClickHandler } from './pause-util.js';
 
 /**
- * 퀴즈(Quiz) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정합니다.
+ * 퀴즈(Quiz) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정한다.
  *
- * 이 함수는 pause 모달(`<dialog>` 요소)에 대해 퀴즈 게임 전용 pause 로직을 바인딩하며,
- * 버튼 클릭 시 수행할 동작을 `setupPauseDialogClickHandler`를 통해 등록합니다.
+ * 이 함수는 pause 모달('<dialog>' 요소)에 대해 퀴즈 게임 전용 pause 로직을 바인딩하며,
+ * 버튼 클릭 시 수행할 동작을 'setupPauseDialogClickHandler'를 통해 등록한다.
  *
  * 각 버튼의 동작은 다음과 같습니다:
- * - `.continue-btn`: 게임을 계속 진행
- * - `.retry-btn`: 게임을 처음부터 다시 시작
- * - `.main-btn`: 메인 화면으로 이동
+ * - '.continue-btn': 게임을 계속 진행
+ * - '.retry-btn': 게임을 처음부터 다시 시작
+ * - '.main-btn': 메인 화면으로 이동
  *
- * @param {HTMLDialogElement} dialog - 일시정지 모달 `<dialog>` 요소
+ * @param {HTMLDialogElement} dialog - 일시정지 모달 '<dialog>' 요소
  */
 export function handleQuizPause(dialog) {
   // console.log는 디버깅용으로 사용

--- a/src/components/modal/pause-modal/whack-pause.js
+++ b/src/components/modal/pause-modal/whack-pause.js
@@ -1,17 +1,17 @@
 import { setupPauseDialogClickHandler } from './pause-util.js';
 
 /**
- * 두더지 잡기(Whack-a-Mole) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정합니다.
+ * 두더지 잡기(Whack-a-Mole) 게임에서 일시정지 모달의 버튼 클릭 핸들러를 설정한다.
  *
  * 이 함수는 pause 모달(dialog)에 대해 게임별 pause 로직을 바인딩하며,
- * 버튼 클릭 시 실행될 콜백 함수를 `setupPauseDialogClickHandler`를 통해 등록합니다.
+ * 버튼 클릭 시 실행될 콜백 함수를 'setupPauseDialogClickHandler'를 통해 등록한다.
  *
- * 각 버튼의 동작은 다음과 같습니다:
- * - `.continue-btn`: 게임을 계속 진행
- * - `.retry-btn`: 게임을 처음부터 다시 시작
- * - `.main-btn`: 메인 화면으로 이동
+ * 각 버튼의 동작은 다음과 같다.
+ * - '.continue-btn': 게임을 계속 진행
+ * - '.retry-btn': 게임을 처음부터 다시 시작
+ * - '.main-btn': 메인 화면으로 이동
  *
- * @param {HTMLDialogElement} dialog - 일시정지 모달 `<dialog>` 요소
+ * @param {HTMLDialogElement} dialog - 일시정지 모달 '<dialog>' 요소
  */
 export function handleWhackPause(dialog) {
   // console.log는 디버깅용으로 사용

--- a/src/components/monitor/monitor.css
+++ b/src/components/monitor/monitor.css
@@ -37,6 +37,7 @@ body {
   border: 30px solid var(--gray-600);
   border-radius: 20px;
   box-sizing: content-box;
+  position: relative;
 }
 
 /* 받침대 이미지 */


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
#### 주요 변경 사항
1. 모달 접근성 개선
- trapFocus 로직 개선: 모달 열릴 때 포커스 트랩 적용, 모니터 프레임 내 모달 외 요소에 inert 속성 추가로 상호작용 차단
- 모달 닫힐 때 inert 해제 및 이전 포커스 복원 처리
- Tab 키 순환, 포커스 이탈 방지 등 키보드 접근성 강화

2. 모달 이벤트 처리 구조 개선
- 모달 열기 버튼(.modal-open) 클릭 시 해당 타입의 모달 dialog를 찾아서 열고, 타입별 핸들러 실행
- 닫기 버튼 클릭 시 dialog.close()로 모달 닫기 및 trapFocus 관련 상태/이벤트 해제
- 모달 닫힘 시 이전 포커스 복원

3. 코드 리팩토링 및 주석 추가
- trapFocus 관련 상태 객체화 및 함수 분리로 가독성/유지보수성 향상
- 각 함수에 jsdoc 주석 추가

4. 모달 내부 inert 처리 및 해제 로직 명확화
- 모니터 프레임 내 모달 외 요소에 inert 속성 추가/제거 로직 개선

#### 테스트 및 확인 사항

- 모달 열기/닫기 시 포커스 트랩 및 상호작용 차단/복원 정상 동작 확인
- 닫기 외 추가 기능 버튼에서도 dialog.close() 호출 시 inert 해제 정상 동작 확인(모달이 닫혔을 때 모니터 프레임 안의 요소들에 접근이 가능한지)
- 다양한 모달 타입(description, scoreboard, settings, pause, register)에서 이벤트 및 trapFocus 정상 동작 확인
- 추가로 리뷰 시 trapFocus 관련 접근성, inert 처리, 이벤트 연결 구조 위주로 확인 부탁드립니다!

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #44 
