### PR TITLE
[fix] 오디오 자동재생 차단 방지: 다양한 사용자 상호작용 이벤트 추가

### DIFF
--- a/src/components/window/controlWindow.js
+++ b/src/components/window/controlWindow.js
@@ -5,7 +5,7 @@
 
   function unmuteAudioOnce() {
     audio.muted = false;
-    // 모든 이벤트 리스너 제거 (한 번만 실행)
+    audio.play().catch(() => {}); // 해제 후 play 재시도
     document.removeEventListener('click', unmuteAudioOnce);
     document.removeEventListener('keydown', unmuteAudioOnce);
     document.removeEventListener('touchstart', unmuteAudioOnce);
@@ -28,6 +28,12 @@
     audio.play().catch((err) => {
       console.warn('자동재생이 차단되었을 수 있습니다:', err);
     });
+
+    // 화면 진행 fallback: 5초 후 화면 강제 전환
+    setTimeout(() => {
+      image.style.display = 'none';
+      screen.style.display = 'flex';
+    }, 5000);
 
     audio.addEventListener('ended', () => {
       image.style.display = 'none';

--- a/src/components/window/controlWindow.js
+++ b/src/components/window/controlWindow.js
@@ -9,6 +9,10 @@
     document.removeEventListener('click', unmuteAudioOnce);
     document.removeEventListener('keydown', unmuteAudioOnce);
     document.removeEventListener('touchstart', unmuteAudioOnce);
+    document.removeEventListener('mousemove', unmuteAudioOnce);
+    document.removeEventListener('wheel', unmuteAudioOnce);
+    document.removeEventListener('touchmove', unmuteAudioOnce);
+    document.removeEventListener('pointerdown', unmuteAudioOnce);
   }
 
   if (audio && image && screen) {
@@ -17,6 +21,10 @@
     document.addEventListener('click', unmuteAudioOnce);
     document.addEventListener('keydown', unmuteAudioOnce);
     document.addEventListener('touchstart', unmuteAudioOnce);
+    document.addEventListener('mousemove', unmuteAudioOnce);
+    document.addEventListener('wheel', unmuteAudioOnce);
+    document.addEventListener('touchmove', unmuteAudioOnce);
+    document.addEventListener('pointerdown', unmuteAudioOnce);
     audio.play().catch((err) => {
       console.warn('자동재생이 차단되었을 수 있습니다:', err);
     });


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- Chrome 등 최신 브라우저의 오디오 자동재생 정책에 대응하여, 음소거 해제된 오디오가 자동재생 차단되는 문제를 개선했습니다.
- 클릭, 키 입력, 터치, 마우스 이동(mousemove), 휠(wheel), 포인터(pointerdown) 등 다양한 사용자 상호작용 이벤트를 추가 등록하여 audio.muted 해제 및 play() 재시도를 트리거하도록 변경했습니다.
- 추가로 오디오가 끝나거나 5초가 지나면 화면이 자동으로 넘어가도록 fallback 처리하였습니다.
- 이로써 실제 사용자가 화면에 진입하자마자 다양한 사용자 상호작용으로 오디오가 재생되고, UX 및 오디오 재생 성공률이 개선됩니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #113 
